### PR TITLE
Dev

### DIFF
--- a/semant.ml
+++ b/semant.ml
@@ -77,11 +77,11 @@ let check (functions, statements) =
     StringMap.empty functions
   in
  
-  let local_func_decls = StringMap.empty
-  in
-
-  let func_decl s = try StringMap.find s func_decls
-      with Not_found -> raise (Failure ("unrecognized function " ^ s))
+  let func_decl func_locals s = 
+            try StringMap.find s func_locals
+      with Not_found ->
+          try StringMap.find s func_decls
+          with Not_found -> raise (Failure ("unrecognized function " ^ s))
   in
 
     (* a main function isn't required for easel *)
@@ -117,26 +117,26 @@ let check (functions, statements) =
     in
 
     (* Return the type of an expression or throw an exception *)
-    let rec expr locals = function
+    let rec expr locals func_locals = function
         IntLit _ -> Int
       | FloatLit _ -> Float
       | BoolLit _ -> Bool
       | PixLit(el)-> (*match el with [e1; e2; e3] -> *)
         (match el with
-          [e1; e2; e3] -> let t1 = expr locals e1 and t2 = expr locals e2 and t3 = expr locals e3 in
+          [e1; e2; e3] -> let t1 = expr locals func_locals e1 and t2 = expr locals func_locals e2 and t3 = expr locals func_locals e3 in
                           if (t1 = Int && t2 = Int && t3 = Int) then Pix 
                           else raise(Failure ("illegal pix value [" ^ string_of_expr e1 ^ string_of_expr e2 ^ string_of_expr e3 ^ "]"))
         | _ -> raise(Failure("Incorrect amount of arguments to use a pix literal")))
-      | ArrLit(el) as arrl -> let t = expr locals (List.hd el) in
+      | ArrLit(el) as arrl -> let t = expr locals func_locals (List.hd el) in
                               let rec tm typ = (function
                                   [] -> ArrRef(typ)
                                 | _ as l -> let h = List.hd l in
-                                            if typ = (expr locals h) then tm typ (List.tl l)
+                                            if typ = (expr locals func_locals h) then tm typ (List.tl l)
                                             else raise(Failure ("Array types in array literal " ^ string_of_expr arrl ^ " do not match"))) in
                               tm t el
                            
       | Id s -> type_of_identifier locals s
-      | Binop(e1, op, e2) as e -> let t1 = expr locals e1 and t2 = expr locals e2 in
+      | Binop(e1, op, e2) as e -> let t1 = expr locals func_locals e1 and t2 = expr locals func_locals e2 in
         (match op with
             Add | Sub | Mult | Div when t1 = Int && t2 = Int -> Int
           | Pow when (t1 = Int || t1 = Float) && (t2 = Int || t2 = Float) -> Float
@@ -147,7 +147,7 @@ let check (functions, statements) =
             string_of_typ t1 ^ " " ^ string_of_op op ^ " " ^
             string_of_typ t2 ^ " in " ^ string_of_expr e))
         )
-      | Unop(op, e) as ex -> let t = expr locals e in
+      | Unop(op, e) as ex -> let t = expr locals func_locals e in
       (match op with
             Neg -> (match t with 
                         Int -> Int
@@ -164,8 +164,8 @@ let check (functions, statements) =
         )
       | Noexpr -> Void
       | Assign(var, e) as ex -> 
-          let lt = type_of_identifier locals (id_of_lval var)
-            and rt = expr locals e in
+            let lt = expr locals func_locals var
+            and rt = expr locals func_locals e in
                   check_assign lt rt (Failure ("illegal assignment " ^ 
                   string_of_typ lt ^ " = " ^ string_of_typ rt ^ " in " ^ string_of_expr ex))
 
@@ -173,15 +173,15 @@ let check (functions, statements) =
       | Call(fdectr, actuals) as call ->
          (match fdectr with
            Id fname -> let fsign = fname ^
-                                   List.fold_left (fun s fm -> s ^ string_of_typ (expr locals fm)) "" actuals in
+                                   List.fold_left (fun s fm -> s ^ string_of_typ (expr locals func_locals fm)) "" actuals in
                       
 
-         let fd = func_decl fsign in
+         let fd = func_decl func_locals fsign in
          if List.length actuals != List.length fd.formals then
            raise (Failure ("expecting " ^ string_of_int
              (List.length fd.formals) ^ " arguments in " ^ string_of_expr call))
          else
-           List.iter2 (fun b e -> let bt = typ_of_bind b in let et = expr locals e in
+           List.iter2 (fun b e -> let bt = typ_of_bind b in let et = expr locals func_locals e in
               ignore (check_assign bt et
                 (Failure ("illegal actual argument found " ^ string_of_typ et ^
                 " expected " ^ string_of_typ bt ^ " in " ^ string_of_expr e))))
@@ -190,11 +190,11 @@ let check (functions, statements) =
            fd.typ
           | _ -> raise(Failure(string_of_expr fdectr ^ " is not a valid function to call" )))
       | EleAt(arr, _) as ele-> (match arr with
-                           EleAt(iarr, _) -> let iat = expr locals iarr in
+                           EleAt(iarr, _) -> let iat = expr locals func_locals iarr in
                                              (match iat with
                                                ArrRef(ArrRef(arr_t)) -> arr_t
                                              | _ -> raise(Failure (string_of_expr ele ^ " is not a valid array")))
-                         | _ -> let iat = expr locals arr in
+                         | _ -> let iat = expr locals func_locals arr in
                                              (match iat with
                                                ArrRef(ArrRef(arr_t)) -> ArrRef(arr_t)
                                              | ArrRef(arr_t) -> arr_t
@@ -202,7 +202,7 @@ let check (functions, statements) =
                            
       | PropAcc(e, prp) -> 
             (* Find the type of a given thing *)
-            let t = expr locals e in
+            let t = expr locals func_locals e in
             (* Make sure the property works for the type *)
             (match t with 
               Pix -> (match prp with
@@ -220,52 +220,60 @@ let check (functions, statements) =
     and check_func func =
         (*TODO: Figure out how to pass anonymous functions when checking statements (is it another list like "locals"?) *)
         report_dup (fun n -> "Duplicate formals in function " ^ func.fname) func.formals;
-        let formals = List.fold_left (fun m (typ, dect) -> (match typ with
-                                                           Func (t,f) -> StringMap.add (string_of_dectr dect) typ m
-                                                         | Void -> raise (Failure ("Illegal Void value for formal"^string_of_dectr dect))
-                                                         | _ -> StringMap.add (string_of_dectr dect) typ m)) StringMap.empty func.formals in
-        check_stmt formals func.typ (Block func.body)
+        List.iter (check_void (fun n -> "Formal arguments cannot have a void type" ^ string_of_dectr n)) func.formals;
+        let func_formals = List.fold_left (fun m (typ, dect) -> (match typ with
+                                                                 Func (t,f) -> let form_func_sign = (string_of_dectr dect) ^ 
+                                                                               List.fold_left(fun s fm -> s ^ string_of_typ fm) "" f in
+                                                                               let form_form_bind = List.map (fun fo -> (fo, DecId("novar"))) f in
+                                                                               let fd = {typ = t; fname = string_of_dectr dect; formals = form_form_bind;
+                                                                                         body=[]; checked=true} in
+                                                                               StringMap.add form_func_sign fd m
+                                                               | _ -> m)) StringMap.empty func.formals in
+        let formals = List.fold_left (fun m (typ, dect) -> StringMap.add (string_of_dectr dect) typ m) StringMap.empty func.formals in
+        ignore (StringMap.iter (fun fdn _ -> print_endline("Local func: " ^ fdn)) func_formals);
 
-    and check_vdef l t = function
+        check_stmt formals func_formals func.typ (Block func.body);ignore(func.checked = true)
+
+    and check_vdef l fl t = function
         InitDectr(d, Noexpr) -> typ_of_bind (t, d)
       | InitDectr(d, e) as initd ->
         let lt = typ_of_bind (t, d)
-        and rt = expr l e in
+        and rt = expr l fl e in
         check_assign lt rt (Failure ("illegal initialization " ^ string_of_typ lt ^
         " = " ^ string_of_typ rt ^ " in " ^ string_of_typ t ^ string_of_initdectr initd))
 
-    and add_locals locals t initds =
+    and add_locals locals func_locals t initds =
         List.fold_left (fun m initd -> match initd with InitDectr(d, e) ->
-            let tt = check_vdef locals t initd in
+            let tt = check_vdef locals func_locals t initd in
             let id = id_of_dectr d in
             if not (StringMap.mem id locals) then StringMap.add id (*fst initd*)tt locals
             else raise (Failure ("duplicate local " ^ id))
         ) locals initds
 
 
-    and check_block locals funct = function
-        [Return _ as s] -> check_stmt locals funct s
+    and check_block locals func_locals funct = function
+        [Return _ as s] -> check_stmt locals func_locals funct s
       | Return _ :: _ -> raise (Failure "nothing may follow a return")
-      | Block sl :: ss -> check_block locals funct sl; check_block locals funct ss
-      | Vdef(t, initds) :: ss -> check_block (add_locals locals t initds) funct ss
-      | s :: ss -> check_stmt locals funct s; check_block locals funct ss
+      | Block sl :: ss -> check_block locals func_locals funct sl; check_block locals func_locals funct ss
+      | Vdef(t, initds) :: ss -> check_block (add_locals locals func_locals t initds) func_locals funct ss
+      | s :: ss -> check_stmt locals func_locals funct s; check_block locals func_locals funct ss
       | [] -> ()
 
-    and check_bool_expr l e = if expr l e != Bool
+    and check_bool_expr l fl e = if expr l fl e != Bool
         then raise (Failure ("expected Boolean expression in " ^ string_of_expr e))
         else ()
 
-    and check_stmt locals funct = function
-        Block sl -> check_block locals funct sl
-      | Expr e -> ignore (expr locals e)
-      | Return e -> let t = expr locals e in if t = funct then () else
+    and check_stmt locals func_locals funct = function
+        Block sl -> check_block locals func_locals funct sl
+      | Expr e -> ignore (expr locals func_locals e)
+      | Return e -> let t = expr locals func_locals e in if t = funct then () else
          raise (Failure ("return gives " ^ string_of_typ t ^ " expected " ^
                          string_of_typ funct ^ " in " ^ string_of_expr e))
-      | If(p, b1, b2) -> check_bool_expr locals p; check_stmt locals funct b1; check_stmt locals funct b2
-      | For(e1, e2, e3, st) -> ignore (expr locals e1); check_bool_expr locals e2;
-                               ignore (expr locals e3); check_stmt locals funct st
-      | While(p, s) -> check_bool_expr locals p; check_stmt locals funct s
-      | Vdef(t, ids) -> raise (Failure ("declaring local variable is only allowed in blocks"))
+      | If(p, b1, b2) -> check_bool_expr locals func_locals p; check_stmt locals func_locals funct b1; check_stmt locals func_locals funct b2
+      | For(e1, e2, e3, st) -> ignore (expr locals func_locals e1); check_bool_expr locals func_locals e2;
+                               ignore (expr locals func_locals e3); check_stmt locals func_locals funct st
+      | While(p, s) -> check_bool_expr locals func_locals p; check_stmt locals func_locals funct s
+      | Vdef(t, ids) -> raise (Failure ("declaring local variable is only allowed in blocks"))*)
     in
 
     (*Only variables defined outside any block are globals*)
@@ -273,7 +281,7 @@ let check (functions, statements) =
         (* initds: init_dectr list *)
         Vdef(t, initds) -> List.iter
             (fun initd -> match initd with InitDectr(d, e) ->
-                let tt = check_vdef StringMap.empty t initd in
+                let tt = check_vdef StringMap.empty StringMap.empty t initd in
                 let id = id_of_dectr d in
                 if not (Hashtbl.mem globals id) then Hashtbl.add globals id (*fst initd*)tt
                 else raise (Failure ("duplicate global " ^ id)))
@@ -282,7 +290,7 @@ let check (functions, statements) =
     in
 
     let check_global_stmt = function
-        stmt -> check_stmt StringMap.empty Int stmt
+        stmt -> check_stmt StringMap.empty StringMap.empty Int stmt
       | _ -> ignore 0
     in
 

--- a/tests/square.es
+++ b/tests/square.es
@@ -1,5 +1,12 @@
 int SQ_W = 300;
-pix canvas[960][960] = [[0]];
+pix canvas[960][960];
+
+int i;
+int j;
+for (i=0; i<canvas.size; i++) {
+    for(j=0; j<canvas[i].size;j++)
+       canvas[i][j]=0; 
+}
 
 function pix[][] graph(pix[][] canvas, function pix (int, int) painter) {
     int x;


### PR DESCRIPTION
Okay, semant is now working I think. Tested using square.es (updated to negate the use of array literals which raise an error if encountered). Also note that expr in semant.ml utilizes a StringMap of local functions, which are defined as formals.